### PR TITLE
fixed NameError when importing elspot

### DIFF
--- a/nordpool/elspot.py
+++ b/nordpool/elspot.py
@@ -143,7 +143,7 @@ class Prices(Base):
         return self.fetch(self.YEARLY, end_date, areas)
 
 
-class AioPrices(elspot.Prices):
+class AioPrices(Prices):
     def __init__(self, currency, client):
 
         super().__init__(currency)


### PR DESCRIPTION
Trying to import elspot (from nordpool import elspot) gives me a name error:

File "<stdin>", line 1, in <module>
File "....\venv\src\nordpool\nordpool\elspot.py", line 146, in <module>
class AioPrices(elspot.Prices):
NameError: name 'elspot' is not defined

I presume it's related to the changes in the async price class?

Anyhow, correcting the class definition to: "class AioPrices(Prices)" instead allows me to import and utilise elspot.