### PR TITLE
Updated split of r['name']

### DIFF
--- a/nordpool/elbas.py
+++ b/nordpool/elbas.py
@@ -47,7 +47,7 @@ class Prices(Base):
             if r['Name'] is None:
                 continue
             else:
-                name = r['Name'].split('-')
+                name = ' '.join(r['Name'].split('-')).split(' ')
             # Picks only "PH" product (hourly)
             if not (name[0] == u'PH'):
                 continue


### PR DESCRIPTION
Parsing datetime (elpas.py at line 54) throws a ValuError (invalid literal for int() with base 10: '01 (X)')
r['Name'] currently only splits with separator "-", it also needs to be split with whitespace.
Could have been done with regex, but regex isn't used anywhere else, so i figured that i just joined the list with whitespace and made a split again with whitespace
