### PR TITLE
ASYNC No input areas behaviour matches SYNC behaviour.

### DIFF
--- a/nordpool/elspot.py
+++ b/nordpool/elspot.py
@@ -260,6 +260,8 @@ class AioPrices(Prices):  # pragma: no cover
                 - list of values (dictionary with start and endtime and value)
                 - possible other values, such as min, max, average for hourly
         """
+        if areas is None:  # If no areas are provided, inherit from the parent class
+            areas = self.AREAS
         data = await self._fetch_json(data_type, end_date, areas=areas)
         return self._parse_json(data, data_type, areas)
 


### PR DESCRIPTION
When calling functions i.e. `prices.hourly()` with no `areas=["XX"]` parameter in an asynchronous environment the default behaviour is to fail on iterating over a None type. This contrasts with a synchronous call where the default behaviour is to iterate over every possible area.

This small changes aims to make the standard behaviour the same for both synchronous and asynchronous calls. 