### PR TITLE
Using iscoroutinefunction over isawaitable in async.

### DIFF
--- a/nordpool/elspot.py
+++ b/nordpool/elspot.py
@@ -226,7 +226,7 @@ class AioPrices(Prices):  # pragma: no cover
 
         resp = await self.client.get(url, params=params)
         # aiohttp
-        if inspect.isawaitable(resp.json()):
+        if inspect.iscoroutinefunction(resp.json):
             return await resp.json()
         # Httpx and asks
         return resp.json()


### PR DESCRIPTION
As the title suggests using `if inspect.iscoroutinefunction(resp.json):` over `if inspect.isawaitable(resp.json):` for checking whether the function is asynchronous for the form required when working with `aiohttp`. 

This change has been made because using `isawaitable` creates unawaited coroutines when checking for the awaitability, giving a warning when code is ran using `aiohttp`. It should not affect `Httpx` and `asks`.