### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nordpool"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python library for fetching Nord Pool spot prices."
 authors = ["Kimmo Huoman <kipenroskaposti@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Update version number in pyproject.toml from 0.5.0 to 0.5.1 to reflect the new patch release.

This prepares the package for the next release which includes the async detection fix and Python 3.14 CI support.